### PR TITLE
Support for folding code regions

### DIFF
--- a/cocor-csharp-syntax.configuration.json
+++ b/cocor-csharp-syntax.configuration.json
@@ -26,5 +26,12 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"]
-    ]
+    ],
+    // support for folding regions
+    "folding": {
+        "markers": {
+            "start": "^\\s*\\/\\/\\s*#region\\s*(.*)$",
+            "end": "^\\s*\\/\\/\\s*#endregion\\s*(.*)$"
+        }
+    }
 }


### PR DESCRIPTION
Adding suppport for folding code regions in the editor using the JavaScript style, //#region name and //#endregion name